### PR TITLE
Add test for extract_sentence_features_from_encoder_outs()

### DIFF
--- a/knn_seq/models/conftest.py
+++ b/knn_seq/models/conftest.py
@@ -1,12 +1,10 @@
-import os
-
 import pytest
 from fairseq import options, tasks
 from fairseq.checkpoint_utils import load_model_ensemble
 from fairseq.dataclass.utils import convert_namespace_to_omegaconf
 
 
-@pytest.fixture
+@pytest.fixture(scope="module")
 def init_models():
     """Load pre-trained model for test."""
 
@@ -17,6 +15,6 @@ def init_models():
     cfg = convert_namespace_to_omegaconf(args)
     task = tasks.setup_task(cfg.task)
 
-    models, saved_args = load_model_ensemble(filenames, task=task)
+    ensemble, saved_args = load_model_ensemble(filenames, task=task)
 
-    return models, saved_args
+    return ensemble, saved_args

--- a/knn_seq/models/fairseq_knn_model_base_test.py
+++ b/knn_seq/models/fairseq_knn_model_base_test.py
@@ -1,13 +1,51 @@
+from typing import List
+
+import pytest
+import torch
+
 from . import fairseq_knn_model_base
 
 
 class TestFairseqKNNModelBase:
-    def test_get_embed_dim(self, init_models) -> None:
-        """test for get_embed_dim()."""
+    @pytest.fixture
+    def init_knn_model_base(self, init_models) -> None:
+        self.ensemble, self.saved_args = init_models
+        self.knn_base = fairseq_knn_model_base.FairseqKNNModelBase(self.ensemble)
 
-        models, saved_args = init_models
-        self.knn_base = fairseq_knn_model_base.FairseqKNNModelBase(models)
+    def test_get_embed_dim(self, init_knn_model_base) -> None:
 
-        test_case: int = saved_args["model"].decoder_embed_dim
         embed_dims = self.knn_base.get_embed_dim()
-        assert embed_dims == [test_case]
+        test_case: List[int] = [
+            model.decoder.embed_tokens.embedding_dim for model in self.ensemble
+        ]
+        assert embed_dims == test_case
+
+    def test_extract_sentence_features_from_encoder_outs(
+        self, init_knn_model_base
+    ) -> None:
+
+        # Optionality test
+        encoder_outs = None
+        assert (
+            self.knn_base.extract_sentence_features_from_encoder_outs(encoder_outs)
+            is None
+        )
+
+        # Encoder out shape test
+        src_tokens = torch.LongTensor([[4, 5, 6]])
+        src_lengths = torch.Tensor([1])
+
+        encoder_outs = [
+            model.encoder(src_tokens=src_tokens, src_lengths=src_lengths)
+            for model in self.ensemble
+        ]
+        sentence_features = self.knn_base.extract_sentence_features_from_encoder_outs(
+            encoder_outs
+        )
+        feature_sizes = [list(feature.size()) for feature in sentence_features]
+
+        test_case: List[List[int]] = [
+            [src_tokens.size()[0], model.encoder.embed_tokens.embedding_dim]
+            for model in self.ensemble
+        ]
+        assert feature_sizes == test_case


### PR DESCRIPTION
Changings are:
- Add `init_knn_model_base` method in order to reuse toy model in this test class.
- Add `test_extract_sentence_features_from_encoder_outs` method
- Rename `models` to `ensemble` as the same variable in fairseq