### PR TITLE
Clear the cache for memory efficiency of subset kNN-MT

### DIFF
--- a/knn_seq/models/fairseq_knn_model_base.py
+++ b/knn_seq/models/fairseq_knn_model_base.py
@@ -71,6 +71,9 @@ class FairseqKNNModelBase(EnsembleModel, metaclass=abc.ABCMeta):
         super().set_decoder_beam_size(beam_size)
         self.beam_size = beam_size
 
+    def clear_cache(self) -> None:
+        """Clear the cache."""
+
     def forward(
         self,
         src_tokens: LongTensor,

--- a/knn_seq/translation_knn.py
+++ b/knn_seq/translation_knn.py
@@ -368,4 +368,5 @@ class TranslationKnnTask(TranslationTask):
                 src_knn_i = model.src_knn[i]
                 print("R-{}\t{}".format(sample_id, " ".join(map(str, src_knn_i))))
 
+        model.clear_cache()
         return results


### PR DESCRIPTION
Subset kNN-MT has the following two caches on a CUDA memory during decoding.
- `subset_tokens` (Tensor): Vocabulary IDs of the subset tokens of shape `(batch_size, max_subset_size)`.
- `subset_index.subset_codes` (List[Tensor]): A list of uint8 PQ codes of subset tokens. The length of the list is equal to the batch size. The shape of each element is `(subset_size, M)`, where `M` is the number of subvectors in PQ.

Since faiss and PyTorch manage CUDA memory separately, they must be explicitly released to reduce the memory footprint.