### PR TITLE
Bump the fairseq version (#104)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{include = "knn_seq"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 torch = "2.0.0"
-fairseq = "0.12.1"
+fairseq = {git = "https://github.com/facebookresearch/fairseq.git", tag = "v0.12.3"}
 faiss-gpu = "^1.7.2"
 sentence-transformers = "^2.2.2"
 h5py = "^3.9.0"


### PR DESCRIPTION
Currently, there are 3 versions in fairseq v0.12.*, but each has a different problem.

- v0.12.1: We can install it with python 3.8 but not with >= 3.9.
- v0.12.2: There is a critical bug in the upstream codes and our unit tests cannot pass.
- v0.12.3: No problem, but we need to install from only the source via git because the wheel package is not created.

Thus, we'll update the requirements to depend on v0.12.3 (git).